### PR TITLE
fix: maintain sort order defined with `orderBy`

### DIFF
--- a/lib/KnormRelations.js
+++ b/lib/KnormRelations.js
@@ -311,6 +311,7 @@ class KnormRelations {
       // TODO: strict mode: throw if the value for the unique field is null or undefined
       getParsedRow(row) {
         let parsedRow = super.getParsedRow(row);
+        this.parsedRows = this.parsedRows || new Map();
 
         if (!this.options.joins) {
           return parsedRow;

--- a/lib/KnormRelations.js
+++ b/lib/KnormRelations.js
@@ -95,6 +95,8 @@ class KnormRelations {
     class RelationsQuery extends Query {
       constructor(model) {
         super(model);
+        // TODO: only initialize parsedRows when needed
+        this.parsedRows = new Map();
         this.options.ensureUniqueField = true;
         this.config.references = model.config.references;
         this.config.referenceFunctions = model.config.referenceFunctions;
@@ -266,7 +268,6 @@ class KnormRelations {
       }
 
       async prepareJoins(query, options) {
-        this.parsedRows = this.parsedRows || new Map();
         return Promise.all(
           this.options.joins.map(async join => {
             // depended on by @knorm/paginate
@@ -364,7 +365,6 @@ class KnormRelations {
       }
 
       parseRows(rows) {
-        this.parsedRows = new Map();
         const parsedRows = super.parseRows(rows);
 
         if (this.options.joins) {

--- a/lib/KnormRelations.js
+++ b/lib/KnormRelations.js
@@ -95,7 +95,6 @@ class KnormRelations {
     class RelationsQuery extends Query {
       constructor(model) {
         super(model);
-        this.parsedRows = {};
         this.options.ensureUniqueField = true;
         this.config.references = model.config.references;
         this.config.referenceFunctions = model.config.referenceFunctions;
@@ -321,10 +320,10 @@ class KnormRelations {
           row[this.formatFieldAlias(this.options.unique, { quote: false })];
 
         if (unique) {
-          if (this.parsedRows[unique]) {
-            parsedRow = this.parsedRows[unique];
+          if (this.parsedRows.has(unique)) {
+            parsedRow = this.parsedRows.get(unique);
           } else {
-            this.parsedRows[unique] = parsedRow;
+            this.parsedRows.set(unique, parsedRow);
           }
         }
 
@@ -363,10 +362,11 @@ class KnormRelations {
       }
 
       parseRows(rows) {
+        this.parsedRows = new Map();
         const parsedRows = super.parseRows(rows);
 
         if (this.options.joins) {
-          return Object.values(this.parsedRows);
+          return Array.from(this.parsedRows.values());
         }
 
         return parsedRows;

--- a/lib/KnormRelations.js
+++ b/lib/KnormRelations.js
@@ -322,9 +322,9 @@ class KnormRelations {
           row[this.formatFieldAlias(this.options.unique, { quote: false })];
 
         if (unique) {
-          row = this.parsedRows.get(unique);
-          if (row) {
-            parsedRow = row;
+          const uniqueRow = this.parsedRows.get(unique);
+          if (uniqueRow) {
+            parsedRow = uniqueRow;
           } else {
             this.parsedRows.set(unique, parsedRow);
           }

--- a/lib/KnormRelations.js
+++ b/lib/KnormRelations.js
@@ -266,6 +266,7 @@ class KnormRelations {
       }
 
       async prepareJoins(query, options) {
+        this.parsedRows = this.parsedRows || new Map();
         return Promise.all(
           this.options.joins.map(async join => {
             // depended on by @knorm/paginate
@@ -311,7 +312,6 @@ class KnormRelations {
       // TODO: strict mode: throw if the value for the unique field is null or undefined
       getParsedRow(row) {
         let parsedRow = super.getParsedRow(row);
-        this.parsedRows = this.parsedRows || new Map();
 
         if (!this.options.joins) {
           return parsedRow;
@@ -321,8 +321,9 @@ class KnormRelations {
           row[this.formatFieldAlias(this.options.unique, { quote: false })];
 
         if (unique) {
-          if (this.parsedRows.has(unique)) {
-            parsedRow = this.parsedRows.get(unique);
+          row = this.parsedRows.get(unique);
+          if (row) {
+            parsedRow = row;
           } else {
             this.parsedRows.set(unique, parsedRow);
           }

--- a/test/KnormRelations.spec.js
+++ b/test/KnormRelations.spec.js
@@ -878,9 +878,11 @@ describe('KnormRelations', () => {
 
         describe("with 'orderBy' configured on the joined query", () => {
           it('fulfils the requested order on the joined model', async () => {
-            await Image.insert({ id: 2, userId: 1, categoryId: 1 });
             await User.insert({ id: 3, name: 'User 3' });
-            await Image.insert({ id: 3, userId: 3, categoryId: 1 });
+            await Image.insert([
+              { id: 2, userId: 1, categoryId: 1 },
+              { id: 3, userId: 3, categoryId: 1 }
+            ]);
 
             const query = new Query(User).leftJoin(
               new Query(Image).orderBy({ id: -1 })
@@ -908,8 +910,7 @@ describe('KnormRelations', () => {
               ]
             );
 
-            await Image.delete({ where: { id: 2 } });
-            await Image.delete({ where: { id: 3 } });
+            await Image.delete({ where: Image.where.in({ id: [2, 3] }) });
             await User.delete({ where: { id: 3 } });
           });
         });

--- a/test/KnormRelations.spec.js
+++ b/test/KnormRelations.spec.js
@@ -877,17 +877,29 @@ describe('KnormRelations', () => {
         });
 
         describe("with 'orderBy' configured on the joined query", () => {
-          it('fulfils the requested order on the joined model', async () => {
+          it.only('fulfils the requested order on the joined model', async () => {
             await Image.insert({ id: 2, userId: 1, categoryId: 1 });
+            await User.insert({ id: 3, name: 'User 3' });
+            await Image.insert({ id: 3, userId: 3, categoryId: 1 });
 
-            const query = new Query(User)
-              .where({ id: 1 })
-              .leftJoin(new Query(Image).orderBy({ id: -1 }));
+            const query = new Query(User).leftJoin(
+              new Query(Image).orderBy({ id: -1 })
+            );
 
             await expect(
               query.fetch(),
-              'to be fulfilled with sorted rows satisfying',
+              'to be fulfilled with value satisfying',
               [
+                new User({
+                  id: 2,
+                  name: 'User 2',
+                  image: null
+                }),
+                new User({
+                  id: 3,
+                  name: 'User 3',
+                  image: [new Image({ id: 3 })]
+                }),
                 new User({
                   id: 1,
                   name: 'User 1',
@@ -897,6 +909,8 @@ describe('KnormRelations', () => {
             );
 
             await Image.delete({ where: { id: 2 } });
+            await Image.delete({ where: { id: 3 } });
+            await User.delete({ where: { id: 3 } });
           });
         });
 

--- a/test/KnormRelations.spec.js
+++ b/test/KnormRelations.spec.js
@@ -877,7 +877,7 @@ describe('KnormRelations', () => {
         });
 
         describe("with 'orderBy' configured on the joined query", () => {
-          it.only('fulfils the requested order on the joined model', async () => {
+          it('fulfils the requested order on the joined model', async () => {
             await Image.insert({ id: 2, userId: 1, categoryId: 1 });
             await User.insert({ id: 3, name: 'User 3' });
             await Image.insert({ id: 3, userId: 3, categoryId: 1 });


### PR DESCRIPTION
When joining in other tables and sorting on one of the joined rows. Then Knorm would change the order of the output array, so it's locally sorted on the id or other unique property. This happened because an object was used, so because the keys would be numbers ouput of Object.values would be sorted on the key.
